### PR TITLE
Provide control over padding in RtpPacketBuilder

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -46,7 +46,7 @@ fn rtp_reader(c: &mut Criterion) {
             b.iter(|| {
                 let header = RtpReader::new(&data).unwrap();
                 assert_eq!(2, header.version());
-                assert!(!header.padding());
+                assert!(header.padding().is_none());
                 assert!(header.extension().is_none());
                 assert_eq!(0, header.csrc_count());
                 assert!(header.mark());

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -369,7 +369,8 @@ mod test {
             .padded(Pad::round_to(4))
             .build().unwrap();
 
-        assert_eq!(packet.len() & 0x03, 0);
+        // assert the length is not increased beyond the 12 bytes of header + the payload
+        assert_eq!(packet.len(), 12 + payload.len());
         assert!(crate::reader::RtpReader::new(&packet).unwrap().padding().is_none());
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -45,15 +45,6 @@ impl Pad {
     pub const fn none() -> Self {
         Pad(PadInner::None)
     }
-    /// Exactly the given number of bytes of padding should be added to the packet length, whatever
-    /// the length of the packet was before padding, and set the `padding` flag in the packet
-    /// header.
-    ///
-    /// Panics if the given value is less than 1.
-    pub const fn add_exactly(pad: u8) -> Self {
-        const_assert!(pad >= 1);
-        Pad(PadInner::AddExactly(pad))
-    }
     /// Add padding bytes so that the resulting packet length will be a multiple of the given
     /// value, and set the `padding` flag in the packet header
     ///
@@ -69,7 +60,6 @@ impl Pad {
 #[derive(Clone)]
 enum PadInner {
     None,
-    AddExactly(u8),
     RoundTo(u8),
 }
 
@@ -77,7 +67,6 @@ impl PadInner {
     pub fn adjust_len(&self, initial_len: usize) -> Option<usize> {
         match self {
             PadInner::None => None,
-            PadInner::AddExactly(n) => Some(*n as usize),
             PadInner::RoundTo(n) => {
                 let remainder = initial_len % *n as usize;
                 if remainder == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!     .ssrc(1337)
 //!     .sequence(Seq::from(1234))
 //!     .timestamp(666657)
-//!     .padded(true)
+//!     .padded(Pad::round_to(4))
 //!     .marked(true)
 //!     .payload(&payload)
 //!     .build();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use crate::{Seq, RtpPacketBuilder, Pad};
+use crate::{Seq, RtpPacketBuilder};
 
 /// Wrapper around a byte-slice of RTP data, providing accessor methods for the RTP header fields.
 pub struct RtpReader<'a> {


### PR DESCRIPTION
The options were previously:
 - pad to 4 bytes
 - no padding

This alters `RtpPacketBuilder::padding()` to allow other padding strategies to be supported:

 - `Pad::none()` - replaces `RtpPacketBuilder::padding(false)`
 - `Pad::round_to(n)` - replaces `RtpPacketBuilder::padding(true)` if `n == 4 `, and also allows for padding to other boundaries by specifying other values for `n`
 - `Pad::add_exactly(n)` manual control over the number of padding bytes to be added.  Maybe too much - I might remove this before release

I don't know of any scenario where padding to other than 4 bytes is needed, but the RTP syntax allows arbitrary padding and this change just seeks to expose that capability.

@WolverinDEV since you initially added the builder code: does your usage include padding, and would this alteration to the API cause you any problems?