### PR TITLE
implemented std::error::Error for error enums

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -332,6 +332,23 @@ impl<'a> RtpPacketBuilder<'a> {
     }
 }
 
+impl std::error::Error for RtpPacketBuildError {}
+
+impl std::fmt::Display for RtpPacketBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                RtpPacketBuildError::BufferTooSmall => "buffer too small",
+                RtpPacketBuildError::PayloadTypeInvalid => "payload type invalid",
+                RtpPacketBuildError::ExtensionTooLarge => "extensions too large",
+                RtpPacketBuildError::ExtensionMissingPadding => "extension missing padding",
+            }
+        )
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{RtpPacketBuilder, Pad};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -281,6 +281,28 @@ impl<'a> fmt::Debug for RtpReader<'a> {
     }
 }
 
+impl std::error::Error for RtpReaderError {}
+
+impl std::fmt::Display for RtpReaderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                RtpReaderError::BufferTooShort(b) => format!("buffer too short: {b}"),
+                RtpReaderError::UnsupportedVersion(v) => format!("unsupported version: {v}"),
+                RtpReaderError::HeadersTruncated {
+                    header_len,
+                    buffer_len,
+                } => format!(
+                    "headers truncated: header length: {header_len}; buffer length: {buffer_len}"
+                ),
+                RtpReaderError::PaddingLengthInvalid(p) => format!("padding length invalid: {p}"),
+            }
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
this makes idiomatic error propagation easier and
allows utilizing crates like thiserror or anyhow

this implements issue #11 