### PR TITLE
Allow for no-std build (extracts std feature, on by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## Unreleased
+- Extracted RtpPacketBuilder::build and Errors to 'std' feature, which is on by default. 
 
 ### Changed
  - Switched to Rust 2021 edition.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ criterion = "0.5"
 [[bench]]
 name = "bench"
 harness = false
+
+[features]
+default = ["std"]
+std = []


### PR DESCRIPTION
The only things keeping rtp-rs from building on no-std are `RtpPacketBuilder::build` (`build_into` is fine), the two Error trait impls, some references to `std` that could be `core`, and some use of `format!` in error messages. After Rust 1.18 the errors can be no-std as well since `std::error::Error` is moving to `core`. But in the meantime I've got this branch that makes this usable, so I figured I'd share it and see if you're interested in supporting that usecase.

Tests, including doc tests, all still work, though I've moved them to use `build_into` except for a doc test that shows `build` still does it's thing. They both delegate the real work to `build_into_unchecked` so it seemed reasonable to me, but let me know if you feel differently.